### PR TITLE
Add Dock badge showing number of failing policies

### DIFF
--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -27,26 +27,20 @@ final class FleetService {
     /// Access only from stateQueue.
     private var _isSettingUp = false
 
-    /// Timer that periodically checks for token rotation.
+    /// Timer that periodically checks for token rotation and refreshes the Dock badge.
+    /// Runs for the lifetime of the service (not stopped when the window closes) so the
+    /// badge keeps updating even when the app is Dock-only.
     private var refreshTimer: Timer?
 
-    /// GCD timer that polls the desktop API for badge data.
-    /// Uses DispatchSourceTimer so it fires even when the window is closed.
-    private var badgeTimer: DispatchSourceTimer?
+    /// Activity token that prevents App Nap from throttling the refresh timer when no
+    /// window is visible. Held for the lifetime of the service.
+    private var activityToken: NSObjectProtocol?
 
-    /// Whether the badge timer is currently suspended. Access only from stateQueue.
-    /// Tracked to keep suspend/resume calls balanced (required by DispatchSourceTimer).
-    private var _badgeTimerSuspended = false
-
-    /// How often (in seconds) to check for a new token.
+    /// How often (in seconds) to check for a new token and refresh the badge.
     private static let tokenRefreshInterval: TimeInterval = 60
 
     /// Delay before retrying a token refresh after a navigation error.
     private static let tokenRetryDelay: TimeInterval = 5
-
-    /// How often (in seconds) to poll the desktop API for badge data when the window is closed.
-    /// When the window is open, badge data is fetched on the 60-second token refresh timer instead.
-    private static let badgePollInterval: TimeInterval = 300
 
     /// Maximum number of consecutive retry attempts on navigation error.
     private static let maxRetryAttempts = 3
@@ -75,10 +69,9 @@ final class FleetService {
 
     deinit {
         refreshTimer?.invalidate()
-        // DispatchSourceTimer must be resumed before cancellation if suspended.
-        if _badgeTimerSuspended { badgeTimer?.resume() }
-        badgeTimer?.cancel()
-        badgeTimer = nil
+        if let token = activityToken {
+            ProcessInfo.processInfo.endActivity(token)
+        }
     }
 
     // MARK: - Public
@@ -251,17 +244,13 @@ final class FleetService {
             browser.onNavigationError = { [weak self] in
                 self?.handleNavigationError()
             }
-            browser.onWindowClose = { [weak self] in
-                self?.stopRefreshTimer()
-            }
             browser.onWindowShow = { [weak self] in
                 self?.refreshTokenIfNeeded()
-                self?.startRefreshTimer()
             }
 
             browser.preload(url: url)
-            self.startBadgePolling()
-            browser.show() // Triggers onWindowShow → startRefreshTimer()
+            browser.show()
+            self.startRefreshTimer()
             self.stateQueue.sync { self._isSettingUp = false }
         }
     }
@@ -286,6 +275,9 @@ final class FleetService {
 
     // MARK: - Token Refresh
 
+    /// Starts the refresh timer and declares an ongoing activity so App Nap
+    /// doesn't throttle the timer when the window is closed. Called once at
+    /// setup time; the timer runs for the lifetime of the service.
     private func startRefreshTimer() {
         refreshTimer?.invalidate()
         let timer = Timer.scheduledTimer(withTimeInterval: Self.tokenRefreshInterval, repeats: true) { [weak self] _ in
@@ -294,13 +286,19 @@ final class FleetService {
         }
         timer.tolerance = 5 // Allow system to coalesce for energy efficiency
         refreshTimer = timer
-        suspendBadgePolling()
-    }
 
-    private func stopRefreshTimer() {
-        refreshTimer?.invalidate()
-        refreshTimer = nil
-        resumeBadgePolling()
+        // Prevent App Nap so the timer keeps firing (and the Dock badge stays
+        // current) when the window is closed.
+        if activityToken == nil {
+            activityToken = ProcessInfo.processInfo.beginActivity(
+                options: .userInitiatedAllowingIdleSystemSleep,
+                reason: "Fleet Desktop badge polling"
+            )
+        }
+
+        // Fetch the badge count immediately so the first update doesn't wait
+        // for the full 60-second interval.
+        fetchDesktopData()
     }
 
     /// Re-reads the token file. If the token has changed, silently reloads the browser with the new URL.
@@ -357,50 +355,6 @@ final class FleetService {
     }
 
     // MARK: - Badge Polling
-
-    /// Starts the GCD timer that periodically fetches the failing policy count.
-    /// Called once from setup(), runs for the lifetime of the process.
-    /// When the window is open, the 60-second refreshTimer also fetches badge data,
-    /// so this timer is suspended to avoid duplicate requests.
-    private func startBadgePolling() {
-        // DispatchSourceTimer must be resumed before cancellation if suspended.
-        if _badgeTimerSuspended { badgeTimer?.resume() }
-        badgeTimer?.cancel()
-        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
-        timer.schedule(
-            deadline: .now(),
-            repeating: Self.badgePollInterval,
-            leeway: .seconds(30)
-        )
-        timer.setEventHandler { [weak self] in
-            self?.fetchDesktopData()
-        }
-        // DispatchSource starts suspended. Only resume if the refreshTimer
-        // isn't already handling badge fetches (browser.show() may have
-        // triggered onWindowShow → startRefreshTimer → suspendBadgePolling
-        // before we get here).
-        let suspended: Bool = stateQueue.sync { _badgeTimerSuspended }
-        if !suspended {
-            timer.resume()
-        }
-        badgeTimer = timer
-    }
-
-    private func suspendBadgePolling() {
-        stateQueue.sync {
-            guard !_badgeTimerSuspended else { return }
-            _badgeTimerSuspended = true
-            badgeTimer?.suspend()
-        }
-    }
-
-    private func resumeBadgePolling() {
-        stateQueue.sync {
-            guard _badgeTimerSuspended else { return }
-            _badgeTimerSuspended = false
-            badgeTimer?.resume()
-        }
-    }
 
     /// Fetches the desktop API endpoint and updates the Dock badge.
     private func fetchDesktopData() {

--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -30,11 +30,23 @@ final class FleetService {
     /// Timer that periodically checks for token rotation.
     private var refreshTimer: Timer?
 
+    /// GCD timer that polls the desktop API for badge data.
+    /// Uses DispatchSourceTimer so it fires even when the window is closed.
+    private var badgeTimer: DispatchSourceTimer?
+
+    /// Whether the badge timer is currently suspended. Access only from stateQueue.
+    /// Tracked to keep suspend/resume calls balanced (required by DispatchSourceTimer).
+    private var _badgeTimerSuspended = false
+
     /// How often (in seconds) to check for a new token.
     private static let tokenRefreshInterval: TimeInterval = 60
 
     /// Delay before retrying a token refresh after a navigation error.
     private static let tokenRetryDelay: TimeInterval = 5
+
+    /// How often (in seconds) to poll the desktop API for badge data when the window is closed.
+    /// When the window is open, badge data is fetched on the 60-second token refresh timer instead.
+    private static let badgePollInterval: TimeInterval = 300
 
     /// Maximum number of consecutive retry attempts on navigation error.
     private static let maxRetryAttempts = 3
@@ -63,6 +75,10 @@ final class FleetService {
 
     deinit {
         refreshTimer?.invalidate()
+        // DispatchSourceTimer must be resumed before cancellation if suspended.
+        if _badgeTimerSuspended { badgeTimer?.resume() }
+        badgeTimer?.cancel()
+        badgeTimer = nil
     }
 
     // MARK: - Public
@@ -162,13 +178,22 @@ final class FleetService {
         }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        URLSession.shared.dataTask(with: request) { _, response, error in
+        URLSession.shared.dataTask(with: request) { [weak self] _, response, error in
             if let error = error {
                 NSLog("Fleet Desktop: Refetch failed: %@", error.localizedDescription)
                 return
             }
             if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
                 NSLog("Fleet Desktop: Refetch returned HTTP %d", http.statusCode)
+                return
+            }
+            // Refetch succeeded — poll the badge soon to catch policy changes
+            // (e.g., an app install that causes a policy to pass).
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 15) {
+                self?.fetchDesktopData()
+            }
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 30) {
+                self?.fetchDesktopData()
             }
         }.resume()
     }
@@ -235,8 +260,8 @@ final class FleetService {
             }
 
             browser.preload(url: url)
-            browser.show()
-            self.startRefreshTimer()
+            self.startBadgePolling()
+            browser.show() // Triggers onWindowShow → startRefreshTimer()
             self.stateQueue.sync { self._isSettingUp = false }
         }
     }
@@ -265,14 +290,17 @@ final class FleetService {
         refreshTimer?.invalidate()
         let timer = Timer.scheduledTimer(withTimeInterval: Self.tokenRefreshInterval, repeats: true) { [weak self] _ in
             self?.refreshTokenIfNeeded()
+            self?.fetchDesktopData()
         }
         timer.tolerance = 5 // Allow system to coalesce for energy efficiency
         refreshTimer = timer
+        suspendBadgePolling()
     }
 
     private func stopRefreshTimer() {
         refreshTimer?.invalidate()
         refreshTimer = nil
+        resumeBadgePolling()
     }
 
     /// Re-reads the token file. If the token has changed, silently reloads the browser with the new URL.
@@ -325,6 +353,99 @@ final class FleetService {
             guard let self = self else { return }
             // Re-read token; if it changed, refreshTokenIfNeeded will reload
             self.refreshTokenIfNeeded()
+        }
+    }
+
+    // MARK: - Badge Polling
+
+    /// Starts the GCD timer that periodically fetches the failing policy count.
+    /// Called once from setup(), runs for the lifetime of the process.
+    /// When the window is open, the 60-second refreshTimer also fetches badge data,
+    /// so this timer is suspended to avoid duplicate requests.
+    private func startBadgePolling() {
+        // DispatchSourceTimer must be resumed before cancellation if suspended.
+        if _badgeTimerSuspended { badgeTimer?.resume() }
+        badgeTimer?.cancel()
+        let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
+        timer.schedule(
+            deadline: .now(),
+            repeating: Self.badgePollInterval,
+            leeway: .seconds(30)
+        )
+        timer.setEventHandler { [weak self] in
+            self?.fetchDesktopData()
+        }
+        // DispatchSource starts suspended. Only resume if the refreshTimer
+        // isn't already handling badge fetches (browser.show() may have
+        // triggered onWindowShow → startRefreshTimer → suspendBadgePolling
+        // before we get here).
+        let suspended: Bool = stateQueue.sync { _badgeTimerSuspended }
+        if !suspended {
+            timer.resume()
+        }
+        badgeTimer = timer
+    }
+
+    private func suspendBadgePolling() {
+        stateQueue.sync {
+            guard !_badgeTimerSuspended else { return }
+            _badgeTimerSuspended = true
+            badgeTimer?.suspend()
+        }
+    }
+
+    private func resumeBadgePolling() {
+        stateQueue.sync {
+            guard _badgeTimerSuspended else { return }
+            _badgeTimerSuspended = false
+            badgeTimer?.resume()
+        }
+    }
+
+    /// Fetches the desktop API endpoint and updates the Dock badge.
+    private func fetchDesktopData() {
+        let (base, token): (String?, String?) = stateQueue.sync { (_baseURL, _currentToken) }
+        guard let baseURL = base,
+              let tok = token,
+              let encoded = tok.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+              let url = URL(string: "\(baseURL)/api/v1/fleet/device/\(encoded)/desktop") else {
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            if let error = error {
+                NSLog("Fleet Desktop: Badge poll failed: %@", error.localizedDescription)
+                return
+            }
+            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                if http.statusCode != 401 && http.statusCode != 403 {
+                    NSLog("Fleet Desktop: Badge poll returned HTTP %d", http.statusCode)
+                }
+                return
+            }
+            guard let data = data else { return }
+            self?.updateBadge(from: data)
+        }.resume()
+    }
+
+    /// Parses the desktop API response and sets the Dock badge label.
+    private func updateBadge(from data: Data) {
+        struct DesktopResponse: Decodable {
+            let failing_policies_count: Int
+        }
+
+        do {
+            let response = try JSONDecoder().decode(DesktopResponse.self, from: data)
+            let label: String? = response.failing_policies_count > 0
+                ? "\(response.failing_policies_count)"
+                : nil
+            DispatchQueue.main.async {
+                NSApp.dockTile.badgeLabel = label
+            }
+        } catch {
+            NSLog("Fleet Desktop: Failed to decode desktop response: %@", error.localizedDescription)
         }
     }
 

--- a/FleetDesktop/Info.plist
+++ b/FleetDesktop/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.fleetdm.fleet-desktop</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>2</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>1.1.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
## Changes

- **Badge Polling**: Implemented a `DispatchSourceTimer` that polls the Fleet desktop API every 5 minutes to fetch the count of failing policies when the window is closed
- **Smart Timer Management**: The badge polling timer is automatically suspended when the refresh timer is active (window open) to avoid duplicate API requests, then resumed when the window closes
- **Dock Integration**: Updates the macOS Dock tile badge label with the failing policy count in real-time
- **API Integration**: Added `fetchDesktopData()` method to call the `/api/v1/fleet/device/{token}/desktop` endpoint and `updateBadge()` to parse and display results
- **Enhanced Refetch**: Updated the refetch flow to trigger additional badge data fetches 15 and 30 seconds after successful refetch to catch policy changes
- **Version Bump**: Updated bundle version to 2 and short version string to 1.1.0

## Implementation Details

- Badge timer uses GCD `DispatchSourceTimer` which fires even when the window is closed (unlike `Timer`)
- Suspend/resume calls are balanced to prevent runtime errors
- Badge updates are dispatched to the main queue for UI updates
- Includes proper error handling and logging for API failures