### PR TITLE
Defer window presentation on headless launch

### DIFF
--- a/FleetDesktop/BrowserWindow.swift
+++ b/FleetDesktop/BrowserWindow.swift
@@ -144,6 +144,11 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
         return webView != nil
     }
 
+    /// Whether the browser window exists and is on-screen (not used for preloaded-only state).
+    var isWindowVisible: Bool {
+        window.map { $0.isVisible } ?? false
+    }
+
     /// Reload the current page in the web view (e.g., Cmd+R).
     func reloadCurrent() {
         webView?.reload()

--- a/FleetDesktop/FleetDesktopApp.swift
+++ b/FleetDesktop/FleetDesktopApp.swift
@@ -33,6 +33,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         fleetService.run()
     }
 
+    func applicationDidBecomeActive(_ notification: Notification) {
+        fleetService.onApplicationDidBecomeActive()
+    }
+
     @objc private func handleURLEvent(_ event: NSAppleEventDescriptor, withReply reply: NSAppleEventDescriptor) {
         guard let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
               let url = URL(string: urlString),

--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -56,6 +56,14 @@ final class FleetService {
     /// Access only from stateQueue.
     private var _pendingRefetch = false
 
+    /// Set when a `fleet://` open needs the browser UI as soon as setup completes (cold launch or still starting).
+    /// Access only from stateQueue.
+    private var _userRequestedFleetUI = false
+
+    /// True after setup if we intentionally skipped the first window show (login item / `open -j`).
+    /// Used to present once when the user foregrounds the app. Main thread only.
+    private var deferredPresentationFromHeadlessLaunch = false
+
     /// Characters to trim from file contents (leading/trailing only).
     private static let trimCharacters = CharacterSet(charactersIn: "\n\r ")
 
@@ -77,12 +85,14 @@ final class FleetService {
     // MARK: - Public
 
     /// Called when the user wants to see the window (app launch, Dock click, etc.).
-    /// On first call, creates the WebView and shows the window.
-    /// On subsequent calls, just brings the existing window forward.
+    /// On first call, creates the WebView; the window is shown unless launch was headless
+    /// (`open -j`, hidden login item) and there was no `fleet://` cold open.
+    /// On subsequent calls, brings the existing window forward.
     func run() {
         // If already set up, just show the window
         if let browser = browserWindow, browser.isAvailable {
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                self?.deferredPresentationFromHeadlessLaunch = false
                 browser.show()
             }
             return
@@ -119,6 +129,14 @@ final class FleetService {
     /// fleet://refetch triggers a device refetch and opens the app.
     /// Unrecognized URLs just bring the app to the foreground.
     func handleFleetURL(_ url: URL) {
+        let browserReady: Bool = stateQueue.sync {
+            guard let b = browserWindow else { return false }
+            return b.isAvailable
+        }
+        if !browserReady {
+            stateQueue.sync { _userRequestedFleetUI = true }
+        }
+
         let host = url.host?.lowercased()
 
         // fleet://refetch — fire the refetch POST and bring the app forward
@@ -207,7 +225,7 @@ final class FleetService {
         return URL(string: "\(baseURL)/device/\(encoded)/\(encodedPage)")
     }
 
-    /// Reads config, creates the BrowserWindow, loads the URL, shows the window,
+    /// Reads config, creates the BrowserWindow, loads the URL, optionally shows the window,
     /// and starts the refresh timer.
     private func setup() {
         guard resolveConfig() else {
@@ -249,9 +267,41 @@ final class FleetService {
             }
 
             browser.preload(url: url)
-            browser.show()
             self.startRefreshTimer()
-            self.stateQueue.sync { self._isSettingUp = false }
+
+            // Defer the show decision one turn so `NSApp.isActive` reflects hidden login / `open -j`.
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+
+                let userWantsFleetWindow: Bool = self.stateQueue.sync {
+                    let v = self._userRequestedFleetUI
+                    self._userRequestedFleetUI = false
+                    return v
+                }
+                let showNow = NSApp.isActive || userWantsFleetWindow
+                if showNow {
+                    browser.show()
+                    self.deferredPresentationFromHeadlessLaunch = false
+                } else {
+                    self.deferredPresentationFromHeadlessLaunch = true
+                }
+                self.stateQueue.sync { self._isSettingUp = false }
+            }
+        }
+    }
+
+    /// After a headless launch, present the window the first time the user foregrounds the app
+    /// (e.g. Cmd-Tab). Dock clicks use `applicationShouldHandleReopen` → `run()` instead.
+    func onApplicationDidBecomeActive() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            guard self.deferredPresentationFromHeadlessLaunch, NSApp.isActive else { return }
+            guard let browser = self.browserWindow, browser.isAvailable, !browser.isWindowVisible else {
+                self.deferredPresentationFromHeadlessLaunch = false
+                return
+            }
+            browser.show()
+            self.deferredPresentationFromHeadlessLaunch = false
         }
     }
 

--- a/FleetDesktop/Info.plist
+++ b/FleetDesktop/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.fleetdm.fleet-desktop</string>
     <key>CFBundleVersion</key>
-    <string>2</string>
+    <string>3</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1.0</string>
+    <string>1.2.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
Add logic to defer showing the browser window when the app is launched headless (hidden login item or `open -j`) and present it later when the user foregrounds the app. Introduces BrowserWindow.isWindowVisible, hooks applicationDidBecomeActive in AppDelegate, and adds _userRequestedFleetUI and deferredPresentationFromHeadlessLaunch flags in FleetService. Adjusts run(), setup(), and handleFleetURL() to track user-initiated fleet:// opens before the UI is ready and to only show the window immediately if NSApp.isActive or a fleet:// request occurred; otherwise the window is preloaded and shown once upon activation. Thread-safety notes: stateQueue is used to access internal flags as appropriate.