### PR TITLE
Reload Policies tab on badge change; bump version

### DIFF
--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -64,6 +64,16 @@ final class FleetService {
     /// Used to present once when the user foregrounds the app. Main thread only.
     private var deferredPresentationFromHeadlessLaunch = false
 
+    /// Most recent `failing_policies_count` from the desktop API.
+    /// Access only from stateQueue.
+    private var _lastBadgeCount: Int?
+
+    /// The `failing_policies_count` reflected by the currently loaded web page.
+    /// Compared to `_lastBadgeCount` when the window is shown to detect a stale
+    /// Policies tab (e.g. badge dropped to 0 while the window was closed).
+    /// Access only from stateQueue.
+    private var _pageBadgeCount: Int?
+
     /// Characters to trim from file contents (leading/trailing only).
     private static let trimCharacters = CharacterSet(charactersIn: "\n\r ")
 
@@ -159,6 +169,7 @@ final class FleetService {
         // If the browser is already set up, navigate (or just show) the window
         if let browser = browserWindow, browser.isAvailable {
             if let page = page, let target = deviceURL(page: page) {
+                stateQueue.sync { _pageBadgeCount = _lastBadgeCount }
                 DispatchQueue.main.async {
                     browser.reload(url: target)
                     browser.show()
@@ -264,6 +275,7 @@ final class FleetService {
             }
             browser.onWindowShow = { [weak self] in
                 self?.refreshTokenIfNeeded()
+                self?.reloadIfPoliciesStale()
             }
 
             browser.preload(url: url)
@@ -364,6 +376,7 @@ final class FleetService {
         guard changed else { return }
         guard let url = deviceURL() else { return }
 
+        stateQueue.sync { _pageBadgeCount = _lastBadgeCount }
         DispatchQueue.main.async {
             browser.reload(url: url)
         }
@@ -442,14 +455,38 @@ final class FleetService {
 
         do {
             let response = try JSONDecoder().decode(DesktopResponse.self, from: data)
-            let label: String? = response.failing_policies_count > 0
-                ? "\(response.failing_policies_count)"
-                : nil
+            let count = response.failing_policies_count
+            let label: String? = count > 0 ? "\(count)" : nil
+            stateQueue.sync {
+                _lastBadgeCount = count
+                // On the first successful poll, seed the page-state count too —
+                // the loaded web page reflects Fleet state at this same moment.
+                if _pageBadgeCount == nil {
+                    _pageBadgeCount = count
+                }
+            }
             DispatchQueue.main.async {
                 NSApp.dockTile.badgeLabel = label
             }
         } catch {
             NSLog("Fleet Desktop: Failed to decode desktop response: %@", error.localizedDescription)
+        }
+    }
+
+    /// Reloads the web view when the badge count differs from what the currently
+    /// loaded page is showing — e.g. user closed the window with 1 failing policy,
+    /// the badge later dropped to 0, and they're reopening to see the change.
+    private func reloadIfPoliciesStale() {
+        let (current, rendered): (Int?, Int?) = stateQueue.sync {
+            (_lastBadgeCount, _pageBadgeCount)
+        }
+        guard let current = current,
+              let rendered = rendered,
+              current != rendered,
+              let browser = browserWindow else { return }
+        stateQueue.sync { _pageBadgeCount = current }
+        DispatchQueue.main.async {
+            browser.reloadCurrent()
         }
     }
 

--- a/FleetDesktop/Info.plist
+++ b/FleetDesktop/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.fleetdm.fleet-desktop</string>
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>4</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.2.0</string>
+    <string>1.2.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
Track desktop API failing_policies_count with two stateQueue-protected fields (_lastBadgeCount and _pageBadgeCount) to detect when the loaded Policies page is stale. Seed _pageBadgeCount on first successful poll, update it when navigating, and call reloadIfPoliciesStale() when the window is shown to reload the web view if the badge count changed while the window was closed. Update polling to maintain _lastBadgeCount and set the Dock badge. Also bump CFBundleVersion to 4 and CFBundleShortVersionString to 1.2.1 in Info.plist.

| # | Trigger | What loads | Code |
|---|---------|-----------|------|
| 1 | App launch (first time service sets up) | Loads `self-service` (or a `fleet://<page>` if a URL handler queued one) | `FleetService.swift:281` `browser.preload(url:)` |
| 2 | User picks **View → Reload Page** / hits Cmd+R | Reloads the current URL | `FleetDesktopApp.swift:101` → `reloadCurrent()` |
| 3 | A `fleet://<page>` URL handler fires while the browser is already up | Loads the requested page (e.g. `fleet://policies` → `/device/<tok>/policies`) | `FleetService.swift:174` `browser.reload(url: target)` |
| 4 | 60-second timer notices the token file rotated | Reloads the same page at the new-token URL | `FleetService.swift:381` `refreshTokenIfNeeded` |
| 5 | Web view hits a navigation error (401/403/Fleet error page) and retry finds a new token | Reloads at the new-token URL | `FleetService.swift:397` `handleNavigationError` |
| 6 | A `.mobileconfig` download finishes | Web view navigates back to the home URL | `BrowserWindow.swift:468` |
| 7 | **NEW.** Window is shown after being closed, and the badge count differs from the count the page was loaded with | Reloads the current URL once | `FleetService.swift:489` `reloadIfPoliciesStale` |
| 8 | Window is shown after being closed and the token rotated while it was closed | Reloads at the new-token URL (already existed — `onWindowShow` was calling `refreshTokenIfNeeded`) | `FleetService.swift:266` |