### PR TITLE
Add fleet://update_all support and bump version

### DIFF
--- a/FleetDesktop/BrowserWindow.swift
+++ b/FleetDesktop/BrowserWindow.swift
@@ -16,6 +16,10 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
     private var loadingOverlay: NSView?
     private var pageLoaded = false
 
+    /// JavaScript to run on the next `didFinish` navigation. Consumed once.
+    /// Used by `fleet://update_all` to click the in-page "Update all" button.
+    private var pendingPostLoadJS: String?
+
     /// Tracks whether an SSO/auth flow is in progress. When true, external IdP
     /// redirects are kept in the WebView so the full redirect chain completes in-app.
     private var ssoFlowActive = false
@@ -161,6 +165,12 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
         webView?.load(URLRequest(url: url))
     }
 
+    /// Queue JavaScript to run once, the next time a navigation finishes loading.
+    /// Set this *before* calling `preload(url:)` or `reload(url:)`.
+    func runOnNextLoad(_ js: String) {
+        pendingPostLoadJS = js
+    }
+
     // MARK: - Loading Overlay
 
     private func addLoadingOverlay() {
@@ -264,6 +274,7 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
         window = nil
         loadingOverlay?.removeFromSuperview()
         loadingOverlay = nil
+        pendingPostLoadJS = nil
         resetSSOFlow()
         onWindowClose?()
     }
@@ -286,6 +297,14 @@ extension BrowserWindow: WKNavigationDelegate {
         // Check if the page content indicates an error (Fleet returns 200 with error HTML
         // when the token is expired, rather than a 401/403 status code)
         checkPageForErrors(webView)
+
+        // Only run queued JS on Fleet-host pages — avoids injecting into IdP
+        // pages during SSO redirects and avoids consuming the slot on an
+        // intermediate redirect before the real target finishes loading.
+        if let js = pendingPostLoadJS, webView.url?.host == fleetHost {
+            pendingPostLoadJS = nil
+            webView.evaluateJavaScript(js, completionHandler: nil)
+        }
     }
 
     /// Inspects the page DOM for error indicators that suggest the device token has expired.

--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -56,6 +56,10 @@ final class FleetService {
     /// Access only from stateQueue.
     private var _pendingRefetch = false
 
+    /// Whether an update-all was requested via fleet://update_all before setup completed.
+    /// Access only from stateQueue.
+    private var _pendingUpdateAll = false
+
     /// Set when a `fleet://` open needs the browser UI as soon as setup completes (cold launch or still starting).
     /// Access only from stateQueue.
     private var _userRequestedFleetUI = false
@@ -161,6 +165,23 @@ final class FleetService {
             return
         }
 
+        // fleet://update_all (or fleet://update-all) — open the self-service page
+        // and click its "Update all" button via the WebView so the install logic
+        // stays defined by Fleet's UI rather than duplicated here.
+        if host == "update_all" || host == "update-all" {
+            let ready: Bool = stateQueue.sync {
+                guard let b = browserWindow else { return false }
+                return b.isAvailable
+            }
+            if ready {
+                triggerUpdateAll()
+            } else {
+                stateQueue.sync { _pendingUpdateAll = true }
+                run()
+            }
+            return
+        }
+
         let page: String? = {
             guard let host = host, Self.validPages.contains(host) else { return nil }
             return host
@@ -220,6 +241,44 @@ final class FleetService {
         }.resume()
     }
 
+    /// Navigates to the self-service page and clicks its "Update all" button,
+    /// reusing the Fleet UI's own filter/install logic. Called when fleet://update_all
+    /// arrives after the browser has been set up.
+    private func triggerUpdateAll() {
+        guard let target = deviceURL(page: "self-service"),
+              let browser = browserWindow else { return }
+        DispatchQueue.main.async {
+            browser.runOnNextLoad(Self.updateAllJS)
+            browser.reload(url: target)
+            browser.show()
+        }
+    }
+
+    /// JS injected into the self-service page to click its "Update all" button.
+    /// Retries for a few seconds because the React UI mounts asynchronously after
+    /// `didFinish`. Matching on visible button text keeps the install logic owned
+    /// by Fleet's UI rather than duplicated in this app.
+    private static let updateAllJS = """
+    (function() {
+        var attempts = 0;
+        var maxAttempts = 60; // ~30s at 500ms
+        function tryClick() {
+            var btns = document.querySelectorAll('button');
+            for (var i = 0; i < btns.length; i++) {
+                var label = (btns[i].textContent || '').trim();
+                if (label === 'Update all' && !btns[i].disabled) {
+                    btns[i].click();
+                    return;
+                }
+            }
+            if (++attempts < maxAttempts) {
+                setTimeout(tryClick, 500);
+            }
+        }
+        tryClick();
+    })();
+    """
+
     // MARK: - Private
 
     /// Builds a device page URL from the base URL, current token, and page name.
@@ -251,16 +310,20 @@ final class FleetService {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 
-            let (page, shouldRefetch): (String, Bool) = self.stateQueue.sync {
+            let (requestedPage, shouldRefetch, shouldUpdateAll): (String, Bool, Bool) = self.stateQueue.sync {
                 let p = self._pendingPage ?? "self-service"
                 self._pendingPage = nil
                 let r = self._pendingRefetch
                 self._pendingRefetch = false
-                return (p, r)
+                let u = self._pendingUpdateAll
+                self._pendingUpdateAll = false
+                return (p, r, u)
             }
             if shouldRefetch {
                 self.performRefetch()
             }
+            // Update-all requires the self-service page so the button is in the DOM.
+            let page = shouldUpdateAll ? "self-service" : requestedPage
             guard let url = self.deviceURL(page: page) else {
                 self.stateQueue.sync { self._isSettingUp = false }
                 self.showError("Unable to construct self-service URL. Check Fleet configuration.")
@@ -278,6 +341,9 @@ final class FleetService {
                 self?.reloadIfPoliciesStale()
             }
 
+            if shouldUpdateAll {
+                browser.runOnNextLoad(Self.updateAllJS)
+            }
             browser.preload(url: url)
             self.startRefreshTimer()
 

--- a/FleetDesktop/Info.plist
+++ b/FleetDesktop/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.fleetdm.fleet-desktop</string>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>5</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.2.1</string>
+    <string>1.3.0</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
Support fleet://update_all (and fleet://update-all) by queuing a one-time JS snippet that clicks the self-service 'Update all' button after the Fleet page finishes loading. BrowserWindow gains a pendingPostLoadJS slot, a runOnNextLoad() helper, and logic to evaluate the queued JS only for Fleet-host pages (avoiding IdP redirects); the pending JS is cleared on window close. FleetService adds a _pendingUpdateAll flag, handling to trigger or queue the update_all flow, a triggerUpdateAll() helper, and a retrying updateAllJS snippet that looks for a visible 'Update all' button and clicks it. Also adjusts startup flow so update-all forces the self-service page and injects the JS as needed. Finally, Info.plist version info is bumped to CFBundleVersion 5 and CFBundleShortVersionString 1.3.0.