### PR TITLE
Implement single-instance handling and update macOS app version to 1.3.2

### DIFF
--- a/FleetDesktop/FleetDesktopApp.swift
+++ b/FleetDesktop/FleetDesktopApp.swift
@@ -15,20 +15,53 @@ struct FleetDesktopMain {
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private let fleetService = FleetService()
 
+    /// True if another instance of this app was already running when we launched.
+    /// A secondary instance forwards any fleet:// URL to the primary and exits,
+    /// so macOS never shows a second Dock icon.
+    private var isSecondaryInstance = false
+
+    /// Distributed notifications used to hand work from a short-lived duplicate
+    /// instance to the already-running primary before the duplicate exits.
+    private static let forwardURLNotification = Notification.Name("com.fleetdm.fleet-desktop.openURL")
+    private static let forwardReopenNotification = Notification.Name("com.fleetdm.fleet-desktop.reopen")
+
     func applicationWillFinishLaunching(_ notification: Notification) {
-        // Register handler for fleet:// URLs before the system delivers them.
-        // On a cold launch via URL, macOS delivers the Apple Event between
-        // willFinishLaunching and didFinishLaunching — registering here ensures
-        // the event is captured and pending state is set before run() is called.
+        // Register the fleet:// handler before the system delivers the launch URL.
+        // macOS delivers the Apple Event between willFinishLaunching and
+        // didFinishLaunching, so registering here captures it even for a duplicate
+        // instance that exists only to forward the URL to the primary.
         NSAppleEventManager.shared().setEventHandler(
             self,
             andSelector: #selector(handleURLEvent(_:withReply:)),
             forEventClass: AEEventClass(kInternetEventClass),
             andEventID: AEEventID(kAEGetURL)
         )
+
+        // Single-instance guard. macOS normally coalesces launches of the same
+        // bundle, but that breaks when the binary is exec'd directly, the app runs
+        // from a translocated path, or multiple bundle copies are registered — any
+        // of which leaves duplicate Dock icons. If a primary is already running we
+        // become a secondary: hand off (URL or reopen) and exit before showing UI.
+        if isAlreadyRunningElsewhere() {
+            isSecondaryInstance = true
+            return
+        }
+
+        // Primary: listen for hand-offs from any future duplicate instance.
+        let dnc = DistributedNotificationCenter.default()
+        dnc.addObserver(self, selector: #selector(handleForwardedURL(_:)),
+                        name: Self.forwardURLNotification, object: nil)
+        dnc.addObserver(self, selector: #selector(handleForwardedReopen(_:)),
+                        name: Self.forwardReopenNotification, object: nil)
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // A secondary instance with no fleet:// URL (a plain relaunch): tell the
+        // primary to reopen its window, then exit so we leave no Dock icon behind.
+        if isSecondaryInstance {
+            forwardReopenToPrimary()
+            activatePrimaryAndTerminate()
+        }
         setupMainMenu()
         fleetService.run()
     }
@@ -43,7 +76,70 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
               url.scheme?.lowercased() == "fleet" else {
             return
         }
+        // Secondary instance: forward the deep link to the primary and exit so the
+        // duplicate never materializes as its own Dock icon.
+        if isSecondaryInstance {
+            forwardURLToPrimary(url)
+            activatePrimaryAndTerminate()
+        }
         fleetService.handleFleetURL(url)
+    }
+
+    // MARK: - Single-Instance Handoff
+
+    /// Whether another instance of this bundle (with a lower PID — the primary) is
+    /// already running. Comparing PIDs makes the choice deterministic if two
+    /// instances ever launch simultaneously: the lowest PID stays, the rest exit.
+    private func isAlreadyRunningElsewhere() -> Bool {
+        guard let bundleID = Bundle.main.bundleIdentifier else { return false }
+        let mine = NSRunningApplication.current.processIdentifier
+        return NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+            .contains { $0.processIdentifier < mine }
+    }
+
+    /// Hands a fleet:// deep link to the primary instance over a distributed
+    /// notification. `deliverImmediately` flushes it before we exit(0).
+    private func forwardURLToPrimary(_ url: URL) {
+        DistributedNotificationCenter.default().postNotificationName(
+            Self.forwardURLNotification,
+            object: nil,
+            userInfo: ["url": url.absoluteString],
+            deliverImmediately: true
+        )
+    }
+
+    /// Asks the primary instance to reopen its window (plain relaunch with no URL).
+    private func forwardReopenToPrimary() {
+        DistributedNotificationCenter.default().postNotificationName(
+            Self.forwardReopenNotification,
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+    }
+
+    /// Bring the primary instance forward, then exit immediately. A secondary has
+    /// created no windows or timers, so exit(0) is clean and skips any further
+    /// delegate callbacks.
+    private func activatePrimaryAndTerminate() -> Never {
+        if let bundleID = Bundle.main.bundleIdentifier {
+            let mine = NSRunningApplication.current.processIdentifier
+            NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+                .filter { $0.processIdentifier != mine }
+                .min(by: { $0.processIdentifier < $1.processIdentifier })?
+                .activate(options: [.activateAllWindows])
+        }
+        exit(0)
+    }
+
+    @objc private func handleForwardedURL(_ notification: Notification) {
+        guard let urlString = notification.userInfo?["url"] as? String,
+              let url = URL(string: urlString) else { return }
+        fleetService.handleFleetURL(url)
+    }
+
+    @objc private func handleForwardedReopen(_ notification: Notification) {
+        fleetService.run()
     }
 
     // MARK: - Main Menu

--- a/FleetDesktop/Info.plist
+++ b/FleetDesktop/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.fleetdm.fleet-desktop</string>
     <key>CFBundleVersion</key>
-    <string>6</string>
+    <string>7</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.3.1</string>
+    <string>1.3.2</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/FleetDesktop/Info.plist
+++ b/FleetDesktop/Info.plist
@@ -22,6 +22,8 @@
     <string>13.0</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>LSMultipleInstancesProhibited</key>
+    <true/>
     <key>CFBundleURLTypes</key>
     <array>
         <dict>


### PR DESCRIPTION
This pull request enhances the Fleet Desktop app to ensure only a single instance runs at a time, even in edge cases where macOS might otherwise allow duplicates (such as running from different paths or direct binary execution). It introduces a mechanism for secondary instances to forward deep links or relaunch events to the primary instance and exit cleanly, preventing duplicate Dock icons and ensuring a seamless user experience. Additionally, the app version is incremented and a new Info.plist key is set to further enforce single-instance behavior.

**Single-instance enforcement and handoff:**

* Added logic to detect if another instance is already running (`isAlreadyRunningElsewhere`). If so, the new instance becomes a "secondary," forwards any `fleet://` URL or relaunch event to the primary instance via distributed notifications, and exits before showing UI. This prevents duplicate Dock icons and ensures only one instance handles app events. [[1]](diffhunk://#diff-27d5df4f964be2d5f6cdcd503cf742a504b571926fbf65994c8a4c7c2188e096R18-R64) [[2]](diffhunk://#diff-27d5df4f964be2d5f6cdcd503cf742a504b571926fbf65994c8a4c7c2188e096R79-R144)
* Implemented distributed notification handlers (`handleForwardedURL`, `handleForwardedReopen`) in the primary instance to process URLs or relaunch requests forwarded by secondary instances.
* Added helper methods (`forwardURLToPrimary`, `forwardReopenToPrimary`, `activatePrimaryAndTerminate`) to facilitate communication and clean exit of secondary instances.

**Info.plist updates:**

* Set the `LSMultipleInstancesProhibited` key to `true` to instruct macOS to avoid launching multiple instances of the app when possible.
* Bumped the app version and build number to `1.3.2 (7)` to reflect these changes.