### PR TITLE
Security and speed fixes from full-repo code review; bump to 1.3.4

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -11,10 +11,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
       
@@ -223,7 +223,7 @@ jobs:
       
       - name: Create Release
         if: steps.check_release.outputs.exists != 'true'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Fleet Desktop ${{ steps.version.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
       - 'LICENSE'
       - '.gitignore'
 
+# Compile check only — no secrets, so it works on pull requests from forks.
+# Signing and notarization happen in build-and-release.yml (manual dispatch).
 jobs:
   build:
     runs-on: macos-latest
@@ -20,197 +22,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
 
       - name: Build app and create pkg
-        id: build
         run: |
           chmod +x build-pkg.sh
           ./build-pkg.sh
-        continue-on-error: false
-
-      - name: Import Developer ID Application Certificate
-        env:
-          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-        run: |
-          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > certificate.p12
-          security create-keychain -p "" build.keychain
-          security default-keychain -s build.keychain
-          security unlock-keychain -p "" build.keychain
-          security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
-          rm certificate.p12
-
-      - name: Code Sign App
-        env:
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          # Find the Developer ID Application certificate
-          CERT_NAME=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | cut -d'"' -f2)
-
-          if [ -z "$CERT_NAME" ]; then
-            echo "Error: Developer ID Application certificate not found"
-            security find-identity -v -p codesigning
-            exit 1
-          fi
-
-          echo "Signing with certificate: $CERT_NAME"
-
-          # Sign the binary directly first (required for universal binaries)
-          BINARY_PATH="build/Fleet Desktop.app/Contents/MacOS/FleetDesktop"
-          echo "Signing binary: $BINARY_PATH"
-          codesign --force --sign "$CERT_NAME" \
-            --options runtime \
-            --timestamp \
-            "$BINARY_PATH"
-
-          # Verify binary signature
-          codesign --verify --verbose "$BINARY_PATH" || exit 1
-
-          # Now sign the app bundle (without --deep since we already signed the binary)
-          echo "Signing app bundle..."
-          codesign --force --sign "$CERT_NAME" \
-            --options runtime \
-            --timestamp \
-            "build/Fleet Desktop.app"
-
-          # Verify the app bundle signature
-          codesign --verify --verbose "build/Fleet Desktop.app" || exit 1
-          codesign --display --verbose=4 "build/Fleet Desktop.app"
-
-          # Check hardened runtime is enabled
-          codesign --display --entitlements - "build/Fleet Desktop.app" || echo "No entitlements (this is OK)"
-
-      - name: Verify app signature before packaging
-        run: |
-          # Verify the app is properly signed
-          codesign --verify --deep --strict --verbose=2 "build/Fleet Desktop.app" || exit 1
-          codesign --display --verbose=2 "build/Fleet Desktop.app"
-          echo "App signature verified successfully"
-
-      - name: Rebuild pkg with signed app
-        run: |
-          chmod +x build-pkg.sh
-          ./build-pkg.sh
-
-      - name: Import Developer ID Installer Certificate
-        env:
-          APPLE_INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_BASE64 }}
-          APPLE_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
-        run: |
-          echo "$APPLE_INSTALLER_CERTIFICATE_BASE64" | base64 --decode > installer_certificate.p12
-          security import installer_certificate.p12 -k build.keychain -P "$APPLE_INSTALLER_CERTIFICATE_PASSWORD" -T /usr/bin/productsign
-          rm installer_certificate.p12
-
-      - name: Sign pkg
-        run: |
-          # Find the Developer ID Installer certificate
-          INSTALLER_CERT=$(security find-identity -v build.keychain 2>/dev/null | grep "Developer ID Installer" | head -1 | cut -d'"' -f2)
-
-          # Fallback: search all keychains
-          if [ -z "$INSTALLER_CERT" ]; then
-            INSTALLER_CERT=$(security find-identity -v | grep "Developer ID Installer" | head -1 | cut -d'"' -f2)
-          fi
-
-          if [ -z "$INSTALLER_CERT" ]; then
-            echo "Error: Developer ID Installer certificate not found"
-            echo "Available identities in build.keychain:"
-            security find-identity -v build.keychain 2>/dev/null || echo "Build keychain not found"
-            echo "Available identities in all keychains:"
-            security find-identity -v
-            exit 1
-          fi
-
-          echo "Found installer certificate: $INSTALLER_CERT"
-
-          # Ensure keychain is unlocked and accessible
-          security unlock-keychain -p "" build.keychain
-          security set-key-partition-list -S apple-tool:,apple:,productsign: -s -k "" build.keychain
-
-          VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "FleetDesktop/Info.plist")
-          UNSIGNED_PKG="build/dist/fleet_desktop-v${VERSION}.pkg"
-          SIGNED_PKG="build/dist/fleet_desktop-v${VERSION}-signed.pkg"
-
-          # Verify pkg exists
-          if [ ! -f "$UNSIGNED_PKG" ]; then
-            echo "Error: Package file not found: $UNSIGNED_PKG"
-            ls -la build/dist/ || echo "build/dist directory does not exist"
-            exit 1
-          fi
-
-          echo "Signing package: $UNSIGNED_PKG"
-          echo "Output will be: $SIGNED_PKG"
-
-          productsign --sign "$INSTALLER_CERT" \
-            --timestamp \
-            "$UNSIGNED_PKG" \
-            "$SIGNED_PKG"
-
-          # Replace unsigned with signed
-          mv "$SIGNED_PKG" "$UNSIGNED_PKG"
-
-          # Verify the signature
-          pkgutil --check-signature "$UNSIGNED_PKG"
-
-      - name: Notarize pkg
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: |
-          VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "FleetDesktop/Info.plist")
-          PKG_PATH="build/dist/fleet_desktop-v${VERSION}.pkg"
-
-          # Submit for notarization and capture submission ID
-          echo "Submitting package for notarization..."
-          SUBMISSION_OUTPUT=$(xcrun notarytool submit "$PKG_PATH" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait \
-            --timeout 30m 2>&1) || NOTARIZATION_FAILED=true
-
-          # Extract submission ID from output
-          SUBMISSION_ID=$(echo "$SUBMISSION_OUTPUT" | grep -i "id:" | head -1 | awk '{print $2}' | tr -d ',' || echo "")
-
-          echo "$SUBMISSION_OUTPUT"
-
-          # If notarization failed, get detailed logs
-          if [ "${NOTARIZATION_FAILED:-false}" = "true" ] || echo "$SUBMISSION_OUTPUT" | grep -qi "Invalid\|failed\|error"; then
-            echo "::error::Notarization failed!"
-            if [ -n "$SUBMISSION_ID" ]; then
-              echo "Fetching detailed notarization log for submission: $SUBMISSION_ID"
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --apple-id "$APPLE_ID" \
-                --password "$APPLE_APP_PASSWORD" \
-                --team-id "$APPLE_TEAM_ID" || echo "Could not fetch log"
-            fi
-            exit 1
-          fi
-
-          # Staple the notarization ticket
-          echo "Stapling notarization ticket..."
-          xcrun stapler staple "$PKG_PATH"
-
-          # Verify notarization
-          echo "Validating notarization..."
-          xcrun stapler validate "$PKG_PATH"
-          spctl --assess --type install --verbose "$PKG_PATH"
-
-      - name: Cleanup keychain
-        if: always()
-        run: |
-          security delete-keychain build.keychain || true
 
       - name: Upload pkg artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: fleet_desktop-pkg
+          name: fleet_desktop-pkg-unsigned
           path: ./build/dist/fleet_desktop-v*.pkg
           retention-days: 30

--- a/FleetDesktop/BrowserWindow.swift
+++ b/FleetDesktop/BrowserWindow.swift
@@ -20,9 +20,28 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
     /// Used by `fleet://update_all` to click the in-page "Update all" button.
     private var pendingPostLoadJS: String?
 
-    /// Tracks whether an SSO/auth flow is in progress. When true, external IdP
-    /// redirects are kept in the WebView so the full redirect chain completes in-app.
-    private var ssoFlowActive = false
+    /// Host of the external IdP page an SSO/auth flow is currently on. Non-nil
+    /// while a flow is in progress; external redirects are kept in the WebView
+    /// so the full redirect chain completes in-app, but navigation is restricted
+    /// to this host (hops to a new host are only allowed via server redirects
+    /// or form submissions).
+    private var ssoHost: String?
+
+    /// When the current SSO flow started. Flows expire after `ssoFlowTimeout`
+    /// so the chrome-less WebView can't render external sites indefinitely.
+    private var ssoFlowStartedAt: Date?
+
+    /// Whether an SSO/auth flow is in progress.
+    private var ssoFlowActive: Bool { ssoHost != nil }
+
+    /// True when an SSO flow has been running longer than `ssoFlowTimeout`.
+    private var ssoFlowExpired: Bool {
+        guard let started = ssoFlowStartedAt else { return false }
+        return Date().timeIntervalSince(started) > Self.ssoFlowTimeout
+    }
+
+    /// How long an SSO flow may run before external navigation is cut off.
+    private static let ssoFlowTimeout: TimeInterval = 10 * 60
 
     /// The window title used throughout the app.
     static let windowTitle = "Fleet Desktop"
@@ -59,7 +78,7 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
     /// Preload the WebView and start loading the URL without showing a window.
     /// Call `show()` later to display the window.
     func preload(url: URL) {
-        fleetHost = url.host
+        fleetHost = url.host?.lowercased()
         homeURL = url
 
         // Configure WKWebView — non-persistent data store so no cookies/cache persist
@@ -160,7 +179,7 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
 
     /// Navigate the existing web view to a new URL (e.g., after token refresh).
     func reload(url: URL) {
-        fleetHost = url.host
+        fleetHost = url.host?.lowercased()
         homeURL = url
         webView?.load(URLRequest(url: url))
     }
@@ -235,7 +254,8 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
     /// Resets SSO state. Called on window close, navigation errors, and
     /// when navigation returns to the Fleet host from an SSO flow.
     private func resetSSOFlow() {
-        ssoFlowActive = false
+        ssoHost = nil
+        ssoFlowStartedAt = nil
     }
 
     // MARK: - External URL Safety
@@ -290,7 +310,7 @@ extension BrowserWindow: WKNavigationDelegate {
 
         // If an SSO flow was active and we've finished loading a Fleet-host page,
         // the SSO callback is complete — reset the flow.
-        if ssoFlowActive, webView.url?.host == fleetHost {
+        if ssoFlowActive, webView.url?.host?.lowercased() == fleetHost {
             resetSSOFlow()
         }
 
@@ -301,7 +321,7 @@ extension BrowserWindow: WKNavigationDelegate {
         // Only run queued JS on Fleet-host pages — avoids injecting into IdP
         // pages during SSO redirects and avoids consuming the slot on an
         // intermediate redirect before the real target finishes loading.
-        if let js = pendingPostLoadJS, webView.url?.host == fleetHost {
+        if let js = pendingPostLoadJS, webView.url?.host?.lowercased() == fleetHost {
             pendingPostLoadJS = nil
             webView.evaluateJavaScript(js, completionHandler: nil)
         }
@@ -390,19 +410,34 @@ extension BrowserWindow: WKNavigationDelegate {
             return
         }
 
+        let requestHost = requestURL.host?.lowercased()
+
         // Always allow same-host and about: URLs
-        if requestURL.host == fleetHost || requestURL.scheme == "about" {
+        if requestHost == fleetHost || requestURL.scheme == "about" {
             decisionHandler(.allow)
             return
         }
 
-        // During an active SSO flow, allow external IdP redirects in the WebView
-        // but only over HTTPS to protect credentials in transit
+        // During an active SSO flow, keep external IdP redirects in the WebView
+        // so the chain completes in-app — but only over HTTPS, only while the
+        // flow is fresh, and only on the current IdP host. Hops to a *new*
+        // external host are allowed via server redirects or form submissions
+        // (multi-host IdP chains); link clicks to unrelated hosts open in the
+        // default browser so the chrome-less WebView can't be steered to
+        // arbitrary sites.
         if ssoFlowActive {
-            if requestURL.scheme?.lowercased() == "https" {
+            guard requestURL.scheme?.lowercased() == "https", !ssoFlowExpired else {
+                resetSSOFlow()
+                decisionHandler(.cancel)
+                return
+            }
+            if requestHost == ssoHost {
+                decisionHandler(.allow)
+            } else if navigationAction.navigationType == .other || navigationAction.navigationType == .formSubmitted {
+                ssoHost = requestHost
                 decisionHandler(.allow)
             } else {
-                resetSSOFlow()
+                openExternalURL(requestURL)
                 decisionHandler(.cancel)
             }
             return
@@ -412,9 +447,10 @@ extension BrowserWindow: WKNavigationDelegate {
         // (server redirect or form submission from Fleet page), start SSO flow.
         // This covers all SSO scenarios: MDM enrollment, IdP login, etc.
         if navigationAction.navigationType == .other || navigationAction.navigationType == .formSubmitted {
-            if navigationAction.sourceFrame.request.url?.host == fleetHost,
+            if navigationAction.sourceFrame.request.url?.host?.lowercased() == fleetHost,
                requestURL.scheme?.lowercased() == "https" {
-                ssoFlowActive = true
+                ssoHost = requestHost
+                ssoFlowStartedAt = Date()
                 decisionHandler(.allow)
                 return
             }
@@ -438,7 +474,8 @@ extension BrowserWindow: WKUIDelegate {
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
         if let url = navigationAction.request.url {
-            if url.host == fleetHost || ssoFlowActive {
+            let host = url.host?.lowercased()
+            if host == fleetHost || (ssoFlowActive && host == ssoHost && !ssoFlowExpired) {
                 webView.load(URLRequest(url: url))
             } else {
                 openExternalURL(url)
@@ -458,7 +495,11 @@ extension BrowserWindow: WKDownloadDelegate {
         completionHandler: @escaping (URL?) -> Void
     ) {
         let downloadsDir = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first!
-        var destination = downloadsDir.appendingPathComponent(suggestedFilename)
+        // The suggested name is server-supplied — keep only the final path
+        // component so the file always lands directly in Downloads.
+        var safeFilename = (suggestedFilename as NSString).lastPathComponent
+        if safeFilename.isEmpty { safeFilename = "download" }
+        var destination = downloadsDir.appendingPathComponent(safeFilename)
 
         // Avoid overwriting existing files — append a number if needed (max 999)
         var counter = 1

--- a/FleetDesktop/BrowserWindow.swift
+++ b/FleetDesktop/BrowserWindow.swift
@@ -258,6 +258,13 @@ final class BrowserWindow: NSObject, NSWindowDelegate {
         ssoFlowStartedAt = nil
     }
 
+    /// Returns the WebView to the Fleet device page. Used to recover from a
+    /// stranded state (expired/abandoned SSO flow on an external page).
+    private func navigateHome() {
+        guard let homeURL = homeURL else { return }
+        webView?.load(URLRequest(url: homeURL))
+    }
+
     // MARK: - External URL Safety
 
     /// Opens a URL externally only if it uses a safe scheme (https, http, mailto).
@@ -427,8 +434,11 @@ extension BrowserWindow: WKNavigationDelegate {
         // arbitrary sites.
         if ssoFlowActive {
             guard requestURL.scheme?.lowercased() == "https", !ssoFlowExpired else {
+                // Flow over (expired or degraded to non-HTTPS). Don't just cancel —
+                // that would strand the WebView on the IdP page; return home.
                 resetSSOFlow()
                 decisionHandler(.cancel)
+                navigateHome()
                 return
             }
             if requestHost == ssoHost {
@@ -456,9 +466,16 @@ extension BrowserWindow: WKNavigationDelegate {
             }
         }
 
-        // External links — open in default browser (scheme-validated)
-        openExternalURL(requestURL)
+        // External links — open in default browser (scheme-validated). But if
+        // the WebView is stranded on an external page with no active flow (an
+        // expired or abandoned SSO), navigate home instead — otherwise every
+        // scripted retry on the stranded page would pop another browser tab.
         decisionHandler(.cancel)
+        if webView.url?.host?.lowercased() == fleetHost {
+            openExternalURL(requestURL)
+        } else {
+            navigateHome()
+        }
     }
 }
 
@@ -524,9 +541,7 @@ extension BrowserWindow: WKDownloadDelegate {
             NSWorkspace.shared.open(url)
 
             // Navigate back to the Fleet self-service homepage
-            if let homeURL = homeURL {
-                webView?.load(URLRequest(url: homeURL))
-            }
+            navigateHome()
         }
     }
 

--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -498,6 +498,13 @@ final class FleetService {
             return false
         }
 
+        // Require HTTPS — the device token is sent to this URL, and a
+        // misconfigured http:// value would put it on the wire in cleartext.
+        guard let parsed = URL(string: fleetURL), parsed.scheme?.lowercased() == "https" else {
+            showError("The configured Fleet URL must use HTTPS.\nCheck the FleetURL managed preference.")
+            return false
+        }
+
         stateQueue.sync { _baseURL = fleetURL.hasSuffix("/") ? String(fleetURL.dropLast()) : fleetURL }
 
         guard let token = readToken() else {
@@ -677,8 +684,21 @@ final class FleetService {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Characters allowed in a device token (alphanumerics plus - and _).
+    /// Rejecting anything else keeps path separators and other URL
+    /// metacharacters out of the device URLs built from the token.
+    private static let tokenAllowedCharacters: CharacterSet = {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-_")
+        return set
+    }()
+
     private func readToken() -> String? {
-        return readFileTrimmed(path: tokenFile)
+        guard let token = readFileTrimmed(path: tokenFile),
+              token.unicodeScalars.allSatisfy({ Self.tokenAllowedCharacters.contains($0) }) else {
+            return nil
+        }
+        return token
     }
 
     private func readFileTrimmed(path: String) -> String? {

--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -281,6 +281,9 @@ final class FleetService {
     private func triggerUpdateAll() {
         guard let target = deviceURL(page: "self-service"),
               let browser = browserWindow else { return }
+        // Mark the badge count as seen before reloading, so onWindowShow's
+        // staleness check doesn't reload the old page and cancel this navigation.
+        stateQueue.sync { _pageBadgeCount = _lastBadgeCount }
         DispatchQueue.main.async {
             browser.runOnNextLoad(Self.updateAllJS)
             browser.reload(url: target)
@@ -334,6 +337,9 @@ final class FleetService {
     private func triggerInstallAll(categoryId: String?) {
         guard let target = deviceURL(page: "self-service", categoryId: categoryId),
               let browser = browserWindow else { return }
+        // Mark the badge count as seen before reloading, so onWindowShow's
+        // staleness check doesn't reload the old page and cancel this navigation.
+        stateQueue.sync { _pageBadgeCount = _lastBadgeCount }
         DispatchQueue.main.async {
             browser.runOnNextLoad(Self.installAllJS)
             browser.reload(url: target)

--- a/FleetDesktop/Info.plist
+++ b/FleetDesktop/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.fleetdm.fleet-desktop</string>
     <key>CFBundleVersion</key>
-    <string>8</string>
+    <string>9</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.3.3</string>
+    <string>1.3.4</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleExecutable</key>

--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -42,7 +42,9 @@ if [ ! -f "$MDM_PLIST" ]; then
 fi
 
 BUNDLE_ID="com.fleetdm.fleet-desktop"
-RUNNING_FLAG="/tmp/.fleet_desktop_was_running"
+# Root-only directory — /tmp is world-writable, so a flag there could be
+# symlink-attacked between install phases.
+RUNNING_FLAG="/var/db/.fleet_desktop_was_running"
 
 # Clean up any stale flag from a previous install
 rm -f "$RUNNING_FLAG"
@@ -89,7 +91,7 @@ cat > "$PKG_DIR/postinstall" << 'POSTINSTALL_EOF'
 
 APP_PATH="/Applications/Fleet Desktop.app"
 BUNDLE_ID="com.fleetdm.fleet-desktop"
-RUNNING_FLAG="/tmp/.fleet_desktop_was_running"
+RUNNING_FLAG="/var/db/.fleet_desktop_was_running"
 
 # Set ownership to root:admin
 chown -R root:admin "$APP_PATH"

--- a/build.sh
+++ b/build.sh
@@ -21,13 +21,18 @@ SOURCES=(
 SDK="$(xcrun --show-sdk-path)"
 SWIFT_FLAGS=(-sdk "$SDK" -parse-as-library -O)
 
-# Build for arm64
+# Build both architectures in parallel; wait on each PID so a failure in
+# either build fails the script (set -e applies to wait's exit status).
 swiftc -target arm64-apple-macos13 "${SWIFT_FLAGS[@]}" \
-    -o "$BUILD_DIR/FleetDesktop-arm64" "${SOURCES[@]}"
+    -o "$BUILD_DIR/FleetDesktop-arm64" "${SOURCES[@]}" &
+ARM64_PID=$!
 
-# Build for x86_64
 swiftc -target x86_64-apple-macos13 "${SWIFT_FLAGS[@]}" \
-    -o "$BUILD_DIR/FleetDesktop-x86_64" "${SOURCES[@]}"
+    -o "$BUILD_DIR/FleetDesktop-x86_64" "${SOURCES[@]}" &
+X86_64_PID=$!
+
+wait "$ARM64_PID"
+wait "$X86_64_PID"
 
 # Create universal binary
 lipo -create \


### PR DESCRIPTION
## Summary

Fixes from a full-repo review covering security, speed, and efficiency, plus a version bump to 1.3.4 (build 9).

### Security

- **Installer flag file**: moved the running-state flag from world-writable `/tmp` to root-only `/var/db`, closing a symlink race (CWE-379) where a local user could make root touch an arbitrary path between the preinstall and postinstall phases.
- **CI signing scope**: the per-push Build workflow no longer imports certificates, signs, or notarizes — it compiles and packages only (artifact renamed `fleet_desktop-pkg-unsigned`). It needs no secrets, so PRs from forks now pass. Signing and notarization remain in the manually-dispatched Build and Release workflow.
- **Supply chain**: all third-party GitHub Actions pinned to commit SHAs (tags kept as comments).
- **HTTPS enforcement**: the app rejects a non-HTTPS `FleetURL` managed preference with a clear error instead of sending the device token over cleartext.
- **Token validation**: device tokens must be alphanumeric plus `-`/`_`, keeping path separators and URL metacharacters out of constructed URLs.
- **SSO hardening**: SSO flows now pin navigation to the current IdP host — hops to a new host are only allowed via server redirects or form submissions (multi-host IdP chains still work), link clicks to unrelated hosts open in the default browser, and flows expire after 10 minutes. Previously an active flow allowed any HTTPS host indefinitely in the chrome-less WebView.
- **Download filenames**: server-supplied filenames are reduced to their last path component before building the destination path in `~/Downloads`.
- **Host comparisons**: all Fleet-host checks are now case-insensitive.

### Speed / efficiency

- `build.sh` compiles arm64 and x86_64 in parallel (~2x faster; verified locally at 165% CPU, 7.2s wall).
- Dropping notarization from per-push CI removes its 5–15 minute wait from every push and PR.

### Version

- 1.3.3 (build 8) → 1.3.4 (build 9).

## Test plan

- [x] `bash -n` passes on both build scripts; workflow YAML parses
- [x] `./build.sh` builds the universal app; built bundle reports 1.3.4 / build 9
- [ ] Smoke-test an SSO login on an MDM-enrolled Mac (the flow policy change is the one behavior that depends on the IdP's real redirect chain)
- [ ] Install the pkg on an MDM-enrolled Mac to exercise the new `/var/db` flag path (quit/relaunch across upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)