### PR TITLE
Mirror review fixes from fleetdm/fleet PR #49469

### DIFF
--- a/FleetDesktop/BrowserWindow.swift
+++ b/FleetDesktop/BrowserWindow.swift
@@ -515,7 +515,7 @@ extension BrowserWindow: WKDownloadDelegate {
         // The suggested name is server-supplied — keep only the final path
         // component so the file always lands directly in Downloads.
         var safeFilename = (suggestedFilename as NSString).lastPathComponent
-        if safeFilename.isEmpty { safeFilename = "download" }
+        if safeFilename.isEmpty || safeFilename == "." || safeFilename == ".." { safeFilename = "download" }
         var destination = downloadsDir.appendingPathComponent(safeFilename)
 
         // Avoid overwriting existing files — append a number if needed (max 999)

--- a/FleetDesktop/FleetDesktopApp.swift
+++ b/FleetDesktop/FleetDesktopApp.swift
@@ -133,13 +133,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func handleForwardedURL(_ notification: Notification) {
+        // Distributed notifications can be posted by any local process, so
+        // re-validate the scheme just like handleURLEvent does, and hop to the
+        // main thread rather than relying on the delivery thread.
         guard let urlString = notification.userInfo?["url"] as? String,
-              let url = URL(string: urlString) else { return }
-        fleetService.handleFleetURL(url)
+              let url = URL(string: urlString),
+              url.scheme?.lowercased() == "fleet" else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.fleetService.handleFleetURL(url)
+        }
     }
 
     @objc private func handleForwardedReopen(_ notification: Notification) {
-        fleetService.run()
+        DispatchQueue.main.async { [weak self] in
+            self?.fleetService.run()
+        }
     }
 
     // MARK: - Main Menu

--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -507,8 +507,13 @@ final class FleetService {
 
         // Require HTTPS — the device token is sent to this URL, and a
         // misconfigured http:// value would put it on the wire in cleartext.
-        guard let parsed = URL(string: fleetURL), parsed.scheme?.lowercased() == "https" else {
-            showError("The configured Fleet URL must use HTTPS.\nCheck the FleetURL managed preference.")
+        // Require a host too: URL(string:) accepts host-less values like
+        // "https://", which would otherwise build a device URL whose host is
+        // the literal path segment "device".
+        guard let parsed = URL(string: fleetURL),
+              parsed.scheme?.lowercased() == "https",
+              let host = parsed.host, !host.isEmpty else {
+            showError("The configured Fleet URL must be a valid HTTPS URL.\nCheck the FleetURL managed preference.")
             return false
         }
 

--- a/FleetDesktop/FleetService.swift
+++ b/FleetDesktop/FleetService.swift
@@ -6,8 +6,9 @@ import AppKit
 /// browser window. Only MDM-managed machines are supported.
 ///
 /// The WebView is kept alive when the window is closed, so reopening is instant.
-/// The token is checked every 60 seconds (timer paused when the window is closed)
-/// and on navigation errors, to handle hourly rotation.
+/// The token is checked every 60 seconds and on navigation errors, to handle
+/// hourly rotation. The timer runs even while the window is closed so the Dock
+/// badge stays current.
 final class FleetService {
     private var browserWindow: BrowserWindow?
 
@@ -324,7 +325,7 @@ final class FleetService {
         guard let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
               let value = items.first(where: { $0.name.lowercased() == "category_id" })?.value,
               !value.isEmpty,
-              value.allSatisfy({ $0.isNumber }) else {
+              value.allSatisfy({ $0.isASCII && $0.isNumber }) else {
             return nil
         }
         return value
@@ -690,14 +691,14 @@ final class FleetService {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    /// Characters allowed in a device token (alphanumerics plus - and _).
-    /// Rejecting anything else keeps path separators and other URL
-    /// metacharacters out of the device URLs built from the token.
-    private static let tokenAllowedCharacters: CharacterSet = {
-        var set = CharacterSet.alphanumerics
-        set.insert(charactersIn: "-_")
-        return set
-    }()
+    /// Characters allowed in a device token (ASCII alphanumerics plus - and _).
+    /// Listed explicitly because CharacterSet.alphanumerics also matches
+    /// non-ASCII Unicode letters and digits. Rejecting anything else keeps path
+    /// separators and other URL metacharacters out of the device URLs built
+    /// from the token.
+    private static let tokenAllowedCharacters = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    )
 
     private func readToken() -> String? {
         guard let token = readFileTrimmed(path: tokenFile),

--- a/build.sh
+++ b/build.sh
@@ -21,8 +21,9 @@ SOURCES=(
 SDK="$(xcrun --show-sdk-path)"
 SWIFT_FLAGS=(-sdk "$SDK" -parse-as-library -O)
 
-# Build both architectures in parallel; wait on each PID so a failure in
-# either build fails the script (set -e applies to wait's exit status).
+# Build both architectures in parallel. Collect both exit statuses before
+# failing — a bare `wait PID` under set -e exits on the first failure and
+# leaves the other swiftc running in the background.
 swiftc -target arm64-apple-macos13 "${SWIFT_FLAGS[@]}" \
     -o "$BUILD_DIR/FleetDesktop-arm64" "${SOURCES[@]}" &
 ARM64_PID=$!
@@ -31,8 +32,14 @@ swiftc -target x86_64-apple-macos13 "${SWIFT_FLAGS[@]}" \
     -o "$BUILD_DIR/FleetDesktop-x86_64" "${SOURCES[@]}" &
 X86_64_PID=$!
 
-wait "$ARM64_PID"
-wait "$X86_64_PID"
+ARM64_STATUS=0
+X86_64_STATUS=0
+wait "$ARM64_PID" || ARM64_STATUS=$?
+wait "$X86_64_PID" || X86_64_STATUS=$?
+if [ "$ARM64_STATUS" -ne 0 ] || [ "$X86_64_STATUS" -ne 0 ]; then
+    echo "swiftc failed (arm64 exit $ARM64_STATUS, x86_64 exit $X86_64_STATUS)" >&2
+    exit 1
+fi
 
 # Create universal binary
 lipo -create \


### PR DESCRIPTION
Mirrors the Copilot/CodeRabbit review fixes that landed on the fleetdm/fleet monorepo sync PR (fleetdm/fleet#49469), so the next sync doesn't clobber them:

**fleetdm/fleet@a860fd4b87:**
- Validate the `fleet://` scheme and dispatch to the main thread in the forwarded-URL/reopen distributed notification handlers (distributed notifications can be posted by any local process)
- Fix the stale header comment claiming the 60s token timer pauses when the window closes (it intentionally runs for the service lifetime to keep the Dock badge current)
- Restrict the device token charset to explicit ASCII alphanumerics (`CharacterSet.alphanumerics` matches non-ASCII Unicode letters/digits)
- Accept only ASCII digits for the deep-link `category_id`
- Treat `.`/`..` server-suggested download filenames as invalid so downloads can't land outside Downloads
- Collect both swiftc exit statuses in build.sh — a bare `wait PID` under `set -e` exits on the first failure and leaves the other build running

**fleetdm/fleet@af6903041d:**
- Require a non-empty host in the FleetURL managed preference. `URL(string: "https://")` passed the scheme-only guard and later built `https://device/TOKEN/self-service` — a URL whose host is the literal segment `device`, with the token in the path.

Verified: `swiftc -typecheck` passes, `./build.sh` builds a universal (x86_64 + arm64) app, and the build-failure path was tested to confirm it reports both exit codes without leaking the sibling process.